### PR TITLE
Turn reporting to Slack in nightly tests on by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
     default: false
   slack_notify:
     type: boolean
-    default: false
+    default: true
   execute_gcp:
     type: boolean
     default: true


### PR DESCRIPTION
Nightly tests ran ok last night, but reporting to Slack was off by default:
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/7557205/174351794-ab3797ab-b0c2-4de1-8c82-e0b92c9147df.png">
